### PR TITLE
Support async interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ quick-xml = "0.18.1"
 derive_more = "0.99.5"
 bytes = "1.0"
 async-trait = "0.1.53"
+httpdate = "1.0.2"
 
 [dev-dependencies]
 tokio = { version = "1.1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4.6"
 quick-xml = "0.18.1"
 derive_more = "0.99.5"
 bytes = "1.0"
+async-trait = "0.1.53"
 
 [dev-dependencies]
 tokio = { version = "1.1", features = ["full"] }

--- a/src/async_object.rs
+++ b/src/async_object.rs
@@ -1,0 +1,260 @@
+use std::collections::HashMap;
+
+use crate::{auth::Auth, prelude::OSS, utils::to_headers};
+
+use super::errors::{Error, ObjectError};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use reqwest::header::{HeaderMap, DATE};
+
+#[async_trait]
+pub trait AsyncObjectAPI {
+    async fn get_object<S1, S2, H, R>(
+        &self,
+        object_name: S1,
+        headers: H,
+        resources: R,
+    ) -> Result<Bytes, Error>
+    where
+        S1: AsRef<str> + Send,
+        S2: AsRef<str> + Send,
+        H: Into<Option<HashMap<S2, S2>>> + Send,
+        R: Into<Option<HashMap<S2, Option<S2>>>> + Send;
+
+    async fn put_object<S1, S2, H, R>(
+        &self,
+        buf: &[u8],
+        object_name: S1,
+        headers: H,
+        resources: R,
+    ) -> Result<(), Error>
+    where
+        S1: AsRef<str> + Send,
+        S2: AsRef<str> + Send,
+        H: Into<Option<HashMap<S2, S2>>> + Send,
+        R: Into<Option<HashMap<S2, Option<S2>>>> + Send;
+
+    async fn copy_object_from_object<S1, S2, S3, H, R>(
+        &self,
+        src: S1,
+        dest: S2,
+        headers: H,
+        resources: R,
+    ) -> Result<(), Error>
+    where
+        S1: AsRef<str> + Send,
+        S2: AsRef<str> + Send,
+        S3: AsRef<str> + Send,
+        H: Into<Option<HashMap<S3, S3>>> + Send,
+        R: Into<Option<HashMap<S3, Option<S3>>>> + Send;
+
+    async fn delete_object<S>(&self, object_name: S) -> Result<(), Error>
+    where
+        S: AsRef<str> + Send;
+}
+
+#[async_trait]
+impl<'a> AsyncObjectAPI for OSS<'a> {
+    async fn get_object<S1, S2, H, R>(
+        &self,
+        object_name: S1,
+        headers: H,
+        resources: R,
+    ) -> Result<Bytes, Error>
+    where
+        S1: AsRef<str> + Send,
+        S2: AsRef<str> + Send,
+        H: Into<Option<HashMap<S2, S2>>> + Send,
+        R: Into<Option<HashMap<S2, Option<S2>>>> + Send,
+    {
+        let object_name = object_name.as_ref();
+        let resources_str = if let Some(r) = resources.into() {
+            self.get_resources_str(r)
+        } else {
+            String::new()
+        };
+        let host = self.host(self.bucket(), object_name, &resources_str);
+        let date = self.date();
+        let mut headers = if let Some(h) = headers.into() {
+            to_headers(h).unwrap()
+        } else {
+            HeaderMap::new()
+        };
+        headers.insert(DATE, date.parse().unwrap());
+        let authorization = self.oss_sign(
+            "GET",
+            self.key_id(),
+            self.key_secret(),
+            self.bucket(),
+            object_name,
+            &resources_str,
+            &headers,
+        );
+        headers.insert("Authorization", authorization.parse().unwrap());
+
+        let resp = reqwest::Client::new()
+            .get(&host)
+            .headers(headers)
+            .send()
+            .await?;
+
+        if resp.status().is_success() {
+            Ok(resp.bytes().await?)
+        } else {
+            Err(Error::Object(ObjectError::GetError {
+                msg: format!("can not get object, status code: {}", resp.status()).into(),
+            }))
+        }
+    }
+
+    async fn put_object<S1, S2, H, R>(
+        &self,
+        buf: &[u8],
+        object_name: S1,
+        headers: H,
+        resources: R,
+    ) -> Result<(), Error>
+    where
+        S1: AsRef<str> + Send,
+        S2: AsRef<str> + Send,
+        H: Into<Option<HashMap<S2, S2>>> + Send,
+        R: Into<Option<HashMap<S2, Option<S2>>>> + Send,
+    {
+        let object_name = object_name.as_ref();
+        let resources_str = if let Some(r) = resources.into() {
+            self.get_resources_str(r)
+        } else {
+            String::new()
+        };
+        let host = self.host(self.bucket(), object_name, &resources_str);
+        let date = self.date();
+
+        let mut headers = if let Some(h) = headers.into() {
+            to_headers(h).unwrap()
+        } else {
+            HeaderMap::new()
+        };
+        headers.insert(DATE, date.parse().unwrap());
+        let authorization = self.oss_sign(
+            "PUT",
+            self.key_id(),
+            self.key_secret(),
+            self.bucket(),
+            object_name,
+            &resources_str,
+            &headers,
+        );
+        headers.insert("Authorization", authorization.parse().unwrap());
+
+        let resp = reqwest::Client::new()
+            .put(&host)
+            .headers(headers)
+            .body(buf.to_owned())
+            .send()
+            .await?;
+
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(Error::Object(ObjectError::DeleteError {
+                msg: format!(
+                    "can not put object, status code, status code: {}",
+                    resp.status()
+                )
+                .into(),
+            }))
+        }
+    }
+
+    async fn copy_object_from_object<S1, S2, S3, H, R>(
+        &self,
+        src: S1,
+        dest: S2,
+        headers: H,
+        resources: R,
+    ) -> Result<(), Error>
+    where
+        S1: AsRef<str> + Send,
+        S2: AsRef<str> + Send,
+        S3: AsRef<str> + Send,
+        H: Into<Option<HashMap<S3, S3>>> + Send,
+        R: Into<Option<HashMap<S3, Option<S3>>>> + Send,
+    {
+        let dest = dest.as_ref();
+        let resources_str = if let Some(r) = resources.into() {
+            self.get_resources_str(r)
+        } else {
+            String::new()
+        };
+        let host = self.host(self.bucket(), dest, &resources_str);
+        let date = self.date();
+        let mut headers = if let Some(h) = headers.into() {
+            to_headers(h)?
+        } else {
+            HeaderMap::new()
+        };
+        headers.insert("x-oss-copy-source", src.as_ref().parse()?);
+        headers.insert(DATE, date.parse()?);
+        let authorization = self.oss_sign(
+            "PUT",
+            self.key_id(),
+            self.key_secret(),
+            self.bucket(),
+            dest,
+            &resources_str,
+            &headers,
+        );
+        headers.insert("Authorization", authorization.parse()?);
+
+        let resp = reqwest::Client::new()
+            .put(&host)
+            .headers(headers)
+            .send()
+            .await?;
+
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(Error::Object(ObjectError::CopyError {
+                msg: format!("can not copy object, status code: {}", resp.status()).into(),
+            }))
+        }
+    }
+
+    async fn delete_object<S>(&self, object_name: S) -> Result<(), Error>
+    where
+        S: AsRef<str> + Send,
+    {
+        let object_name = object_name.as_ref();
+        let host = self.host(self.bucket(), object_name, "");
+        let date = self.date();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(DATE, date.parse()?);
+        let authorization = self.oss_sign(
+            "DELETE",
+            self.key_id(),
+            self.key_secret(),
+            self.bucket(),
+            object_name,
+            "",
+            &headers,
+        );
+        headers.insert("Authorization", authorization.parse()?);
+
+        let resp = reqwest::Client::new()
+            .delete(&host)
+            .headers(headers)
+            .send()
+            .await?;
+
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(Error::Object(ObjectError::DeleteError {
+                msg: format!("can not delete object, status code: {}", resp.status()).into(),
+            }))
+        }
+    }
+}

--- a/src/async_service.rs
+++ b/src/async_service.rs
@@ -1,0 +1,266 @@
+use async_trait::async_trait;
+use quick_xml::{events::Event, Reader};
+use reqwest::header::{HeaderMap, DATE};
+use std::collections::HashMap;
+
+use super::auth::*;
+use super::errors::Error;
+use super::oss::OSS;
+
+#[derive(Clone, Debug)]
+pub struct ListBuckets {
+    prefix: String,
+    marker: String,
+    max_keys: String,
+    is_truncated: bool,
+    next_marker: String,
+
+    id: String,
+    display_name: String,
+
+    buckets: Vec<Bucket>,
+}
+
+impl ListBuckets {
+    pub fn new(
+        prefix: String,
+        marker: String,
+        max_keys: String,
+        is_truncated: bool,
+        next_marker: String,
+        id: String,
+        display_name: String,
+        buckets: Vec<Bucket>,
+    ) -> Self {
+        ListBuckets {
+            prefix,
+            marker,
+            max_keys,
+            is_truncated,
+            next_marker,
+            id,
+            display_name,
+            buckets,
+        }
+    }
+
+    pub fn prefix(&self) -> &str {
+        &self.prefix
+    }
+
+    pub fn marker(&self) -> &str {
+        &self.marker
+    }
+
+    pub fn max_keys(&self) -> &str {
+        &self.max_keys
+    }
+
+    pub fn is_truncated(&self) -> bool {
+        self.is_truncated
+    }
+
+    pub fn next_marker(&self) -> &str {
+        &self.next_marker
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn display_name(&self) -> &str {
+        &self.display_name
+    }
+
+    pub fn buckets(&self) -> &Vec<Bucket> {
+        &self.buckets
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Bucket {
+    name: String,
+    create_date: String,
+    location: String,
+    extranet_endpoint: String,
+    intranet_endpoint: String,
+    storage_class: String,
+}
+
+impl Bucket {
+    pub fn new(
+        name: String,
+        create_date: String,
+        location: String,
+        extranet_endpoint: String,
+        intranet_endpoint: String,
+        storage_class: String,
+    ) -> Self {
+        Bucket {
+            name,
+            create_date,
+            location,
+            extranet_endpoint,
+            intranet_endpoint,
+            storage_class,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn create_data(&self) -> &str {
+        &self.create_date
+    }
+
+    pub fn location(&self) -> &str {
+        &self.location
+    }
+
+    pub fn extranet_endpoint(&self) -> &str {
+        &self.extranet_endpoint
+    }
+
+    pub fn intranet_endpoint(&self) -> &str {
+        &self.intranet_endpoint
+    }
+
+    pub fn storage_class(&self) -> &str {
+        &self.storage_class
+    }
+}
+
+#[async_trait]
+pub trait ServiceAPI {
+    async fn list_bucket<S, R>(&self, resources: R) -> Result<ListBuckets, Error>
+    where
+        S: AsRef<str> + Send,
+        R: Into<Option<HashMap<S, Option<S>>>> + Send;
+}
+
+#[async_trait]
+impl<'a> ServiceAPI for OSS<'a> {
+    async fn list_bucket<S, R>(&self, resources: R) -> Result<ListBuckets, Error>
+    where
+        S: AsRef<str> + Send,
+        R: Into<Option<HashMap<S, Option<S>>>> + Send,
+    {
+        let resources_str = if let Some(r) = resources.into() {
+            self.get_resources_str(r)
+        } else {
+            String::new()
+        };
+        let host = self.endpoint();
+        let date = self.date();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(DATE, date.parse()?);
+        let authorization = self.oss_sign(
+            "GET",
+            self.key_id(),
+            self.key_secret(),
+            "",
+            "",
+            &resources_str,
+            &headers,
+        );
+        headers.insert("Authorization", authorization.parse()?);
+
+        let resp = reqwest::Client::new()
+            .get(host)
+            .headers(headers)
+            .send()
+            .await?;
+
+        let xml_str = resp.text().await?;
+        let mut result = Vec::new();
+        let mut reader = Reader::from_str(xml_str.as_str());
+        reader.trim_text(true);
+        let mut buf = Vec::new();
+
+        let mut prefix = String::new();
+        let mut marker = String::new();
+        let mut max_keys = String::new();
+        let mut is_truncated = false;
+        let mut next_marker = String::new();
+        let mut id = String::new();
+        let mut display_name = String::new();
+
+        let mut name = String::new();
+        let mut location = String::new();
+        let mut create_date = String::new();
+        let mut extranet_endpoint = String::new();
+        let mut intranet_endpoint = String::new();
+        let mut storage_class = String::new();
+
+        let list_buckets;
+
+        loop {
+            match reader.read_event(&mut buf) {
+                Ok(Event::Start(ref e)) => match e.name() {
+                    b"Prefix" => prefix = reader.read_text(e.name(), &mut Vec::new())?,
+                    b"Marker" => marker = reader.read_text(e.name(), &mut Vec::new())?,
+                    b"MaxKeys" => max_keys = reader.read_text(e.name(), &mut Vec::new())?,
+                    b"IsTruncated" => {
+                        is_truncated = reader.read_text(e.name(), &mut Vec::new())? == "true"
+                    }
+                    b"NextMarker" => next_marker = reader.read_text(e.name(), &mut Vec::new())?,
+                    b"ID" => id = reader.read_text(e.name(), &mut Vec::new())?,
+                    b"DisplayName" => display_name = reader.read_text(e.name(), &mut Vec::new())?,
+
+                    b"Bucket" => {
+                        name = String::new();
+                        location = String::new();
+                        create_date = String::new();
+                        extranet_endpoint = String::new();
+                        intranet_endpoint = String::new();
+                        storage_class = String::new();
+                    }
+
+                    b"Name" => name = reader.read_text(e.name(), &mut Vec::new())?,
+                    b"CreationDate" => create_date = reader.read_text(e.name(), &mut Vec::new())?,
+                    b"ExtranetEndpoint" => {
+                        extranet_endpoint = reader.read_text(e.name(), &mut Vec::new())?
+                    }
+                    b"IntranetEndpoint" => {
+                        intranet_endpoint = reader.read_text(e.name(), &mut Vec::new())?
+                    }
+                    b"Location" => location = reader.read_text(e.name(), &mut Vec::new())?,
+                    b"StorageClass" => {
+                        storage_class = reader.read_text(e.name(), &mut Vec::new())?
+                    }
+                    _ => (),
+                },
+                Ok(Event::End(ref e)) if e.name() == b"Bucket" => {
+                    let bucket = Bucket::new(
+                        name.clone(),
+                        create_date.clone(),
+                        location.clone(),
+                        extranet_endpoint.clone(),
+                        intranet_endpoint.clone(),
+                        storage_class.clone(),
+                    );
+                    result.push(bucket);
+                }
+                Ok(Event::Eof) => {
+                    list_buckets = ListBuckets::new(
+                        prefix,
+                        marker,
+                        max_keys,
+                        is_truncated,
+                        next_marker,
+                        id,
+                        display_name,
+                        result,
+                    );
+                    break;
+                } // exits the loop when reaching end of file
+                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+                _ => (), // There are several other `Event`s we do not consider here
+            }
+            buf.clear();
+        }
+        Ok(list_buckets)
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -68,6 +68,8 @@ pub enum ObjectError {
     CopyError { msg: String },
     #[display(fmt = "DELETE ERROR: {}", msg)]
     DeleteError { msg: String },
+    #[display(fmt = "HEAD ERROR: {}", msg)]
+    HeadError { msg: String },
 }
 
 impl StdError for Error {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ extern crate derive_more;
 #[macro_use]
 extern crate log;
 
+pub mod async_object;
+pub mod async_service;
 pub mod errors;
 pub mod object;
 pub mod oss;

--- a/src/object.rs
+++ b/src/object.rs
@@ -1,10 +1,8 @@
 use quick_xml::{events::Event, Reader};
-use reqwest::header::{HeaderMap, CONTENT_LENGTH, DATE};
 use std::collections::HashMap;
 
 use crate::oss::RequestType;
 
-use super::auth::*;
 use super::errors::{Error, ObjectError};
 use super::oss::OSS;
 use super::utils::*;

--- a/src/object.rs
+++ b/src/object.rs
@@ -2,6 +2,8 @@ use quick_xml::{events::Event, Reader};
 use reqwest::header::{HeaderMap, CONTENT_LENGTH, DATE};
 use std::collections::HashMap;
 
+use crate::oss::RequestType;
+
 use super::auth::*;
 use super::errors::{Error, ObjectError};
 use super::oss::OSS;
@@ -83,31 +85,8 @@ impl<'a> ObjectAPI for OSS<'a> {
         H: Into<Option<HashMap<S2, S2>>>,
         R: Into<Option<HashMap<S2, Option<S2>>>>,
     {
-        let object_name = object_name.as_ref();
-        let resources_str = if let Some(r) = resources.into() {
-            self.get_resources_str(r)
-        } else {
-            String::new()
-        };
-        let host = self.host(self.bucket(), object_name, &resources_str);
-        let date = self.date();
-
-        let mut headers = if let Some(h) = headers.into() {
-            to_headers(h)?
-        } else {
-            HeaderMap::new()
-        };
-        headers.insert(DATE, date.parse()?);
-        let authorization = self.oss_sign(
-            "GET",
-            self.key_id(),
-            self.key_secret(),
-            self.bucket(),
-            object_name,
-            &resources_str,
-            &headers,
-        );
-        headers.insert("Authorization", authorization.parse()?);
+        let (host, headers) =
+            self.build_request(RequestType::Get, object_name, headers, resources)?;
 
         let mut resp = reqwest::blocking::Client::new()
             .get(&host)
@@ -166,32 +145,10 @@ impl<'a> ObjectAPI for OSS<'a> {
         H: Into<Option<HashMap<S3, S3>>>,
         R: Into<Option<HashMap<S3, Option<S3>>>>,
     {
-        let object_name = object_name.as_ref();
-        let resources_str = if let Some(r) = resources.into() {
-            self.get_resources_str(r)
-        } else {
-            String::new()
-        };
-        let host = self.host(self.bucket(), object_name, &resources_str);
-        let date = self.date();
+        let (host, headers) =
+            self.build_request(RequestType::Put, object_name, headers, resources)?;
+
         let buf = load_file(file)?;
-        let mut headers = if let Some(h) = headers.into() {
-            to_headers(h)?
-        } else {
-            HeaderMap::new()
-        };
-        headers.insert(DATE, date.parse()?);
-        headers.insert(CONTENT_LENGTH, buf.len().to_string().parse()?);
-        let authorization = self.oss_sign(
-            "PUT",
-            self.key_id(),
-            self.key_secret(),
-            self.bucket(),
-            object_name,
-            &resources_str,
-            &headers,
-        );
-        headers.insert("Authorization", authorization.parse()?);
 
         let resp = reqwest::blocking::Client::new()
             .put(&host)
@@ -221,31 +178,8 @@ impl<'a> ObjectAPI for OSS<'a> {
         H: Into<Option<HashMap<S2, S2>>>,
         R: Into<Option<HashMap<S2, Option<S2>>>>,
     {
-        let object_name = object_name.as_ref();
-        let resources_str = if let Some(r) = resources.into() {
-            self.get_resources_str(r)
-        } else {
-            String::new()
-        };
-        let host = self.host(self.bucket(), object_name, &resources_str);
-        let date = self.date();
-        let mut headers = if let Some(h) = headers.into() {
-            to_headers(h)?
-        } else {
-            HeaderMap::new()
-        };
-        headers.insert(DATE, date.parse()?);
-        headers.insert(CONTENT_LENGTH, buf.len().to_string().parse()?);
-        let authorization = self.oss_sign(
-            "PUT",
-            self.key_id(),
-            self.key_secret(),
-            self.bucket(),
-            object_name,
-            &resources_str,
-            &headers,
-        );
-        headers.insert("Authorization", authorization.parse()?);
+        let (host, headers) =
+            self.build_request(RequestType::Put, object_name, headers, resources)?;
 
         let resp = reqwest::blocking::Client::new()
             .put(&host)
@@ -276,31 +210,9 @@ impl<'a> ObjectAPI for OSS<'a> {
         H: Into<Option<HashMap<S3, S3>>>,
         R: Into<Option<HashMap<S3, Option<S3>>>>,
     {
-        let object_name = object_name.as_ref();
-        let resources_str = if let Some(r) = resources.into() {
-            self.get_resources_str(r)
-        } else {
-            String::new()
-        };
-        let host = self.host(self.bucket(), object_name, &resources_str);
-        let date = self.date();
-        let mut headers = if let Some(h) = headers.into() {
-            to_headers(h)?
-        } else {
-            HeaderMap::new()
-        };
+        let (host, mut headers) =
+            self.build_request(RequestType::Put, object_name, headers, resources)?;
         headers.insert("x-oss-copy-source", src.as_ref().parse()?);
-        headers.insert(DATE, date.parse()?);
-        let authorization = self.oss_sign(
-            "PUT",
-            self.key_id(),
-            self.key_secret(),
-            self.bucket(),
-            object_name,
-            &resources_str,
-            &headers,
-        );
-        headers.insert("Authorization", authorization.parse()?);
 
         let resp = reqwest::blocking::Client::new()
             .put(&host)
@@ -320,22 +232,9 @@ impl<'a> ObjectAPI for OSS<'a> {
     where
         S: AsRef<str>,
     {
-        let object_name = object_name.as_ref();
-        let host = self.host(self.bucket(), object_name, "");
-        let date = self.date();
-
-        let mut headers = HeaderMap::new();
-        headers.insert(DATE, date.parse()?);
-        let authorization = self.oss_sign(
-            "DELETE",
-            self.key_id(),
-            self.key_secret(),
-            self.bucket(),
-            object_name,
-            "",
-            &headers,
-        );
-        headers.insert("Authorization", authorization.parse()?);
+        let headers = HashMap::<String, String>::new();
+        let (host, headers) =
+            self.build_request(RequestType::Delete, object_name, Some(headers), None)?;
 
         let resp = reqwest::blocking::Client::new()
             .delete(&host)


### PR DESCRIPTION
This PR:
- add async API for `Object` and `Service`
- add `head` to `AsyncObject`
```rust
async fn head_object<S>(&self, object_name: S) -> Result<ObjectMeta, Error>;
```
- add `OSS::build_request()` util to simplify request building.

Those new interfaces are tested on a private Aliyun OSS deployment.