### PR TITLE
feat: reuse http client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 repository = "https://github.com/NoXF/oss-rust-sdk"
 
 [dependencies]
-reqwest = { version = "0.11.9", features = ["blocking"] }
+reqwest = { version = "0.11.13", features = ["blocking"] }
 base64 = "0.13"
 chrono = "0.4.20"
 log = "0.4.17"

--- a/src/async_object.rs
+++ b/src/async_object.rs
@@ -77,11 +77,7 @@ impl<'a> AsyncObjectAPI for OSS<'a> {
         let (host, headers) =
             self.build_request(RequestType::Get, object_name, headers, resources)?;
 
-        let resp = reqwest::Client::new()
-            .get(&host)
-            .headers(headers)
-            .send()
-            .await?;
+        let resp = self.http_client.get(&host).headers(headers).send().await?;
 
         if resp.status().is_success() {
             Ok(resp.bytes().await?)
@@ -108,7 +104,8 @@ impl<'a> AsyncObjectAPI for OSS<'a> {
         let (host, headers) =
             self.build_request(RequestType::Put, object_name, headers, resources)?;
 
-        let resp = reqwest::Client::new()
+        let resp = self
+            .http_client
             .put(&host)
             .headers(headers)
             .body(buf.to_owned())
@@ -145,11 +142,7 @@ impl<'a> AsyncObjectAPI for OSS<'a> {
         let (host, mut headers) = self.build_request(RequestType::Put, dest, headers, resources)?;
         headers.insert("x-oss-copy-source", src.as_ref().parse()?);
 
-        let resp = reqwest::Client::new()
-            .put(&host)
-            .headers(headers)
-            .send()
-            .await?;
+        let resp = self.http_client.put(&host).headers(headers).send().await?;
 
         if resp.status().is_success() {
             Ok(())
@@ -168,7 +161,8 @@ impl<'a> AsyncObjectAPI for OSS<'a> {
         let (host, headers) =
             self.build_request(RequestType::Delete, object_name, Some(headers), None)?;
 
-        let resp = reqwest::Client::new()
+        let resp = self
+            .http_client
             .delete(&host)
             .headers(headers)
             .send()
@@ -194,11 +188,7 @@ impl<'a> AsyncObjectAPI for OSS<'a> {
             None,
         )?;
 
-        let resp = reqwest::Client::new()
-            .head(&host)
-            .headers(headers)
-            .send()
-            .await?;
+        let resp = self.http_client.head(&host).headers(headers).send().await?;
 
         if resp.status().is_success() {
             Ok(ObjectMeta::from_header_map(resp.headers())?)


### PR DESCRIPTION
In current implementation, every operation will create a new http client, which
has low performance, since TCP has a slow start.

-   <https://developer.mozilla.org/en-US/docs/Glossary/TCP_slow_start>

