### PR TITLE
make native-tls optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,14 @@
 name = "oss-rust-sdk"
 version = "0.6.1"
 authors = ["NoXF <xianyou.cyq@gmail.com>"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 description = "Aliyun OSS SDK"
 license = "Apache-2.0"
 repository = "https://github.com/NoXF/oss-rust-sdk"
 
 [dependencies]
-reqwest = { version = "0.11.13", features = ["blocking"] }
+reqwest = { version = "0.11.13", features = ["blocking"], default-features = false, optional = true }
 base64 = "0.13"
 chrono = "0.4.20"
 log = "0.4.17"
@@ -23,3 +23,8 @@ sha1 = "0.10"
 
 [dev-dependencies]
 tokio = { version = "1.1", features = ["full"] }
+
+[features]
+default = [ "native-tls" ]
+native-tls = [ "reqwest/default-tls" ]
+rustls-tls = [ "reqwest/rustls-tls" ]


### PR DESCRIPTION
# Default 
```
$ cargo tree -e features -i reqwest
reqwest v0.11.14
├── reqwest feature "__tls"
│   └── reqwest feature "default-tls"
│       └── oss-rust-sdk feature "native-tls"
│           └── oss-rust-sdk feature "default" (command-line)
├── reqwest feature "blocking"
│   └── oss-rust-sdk v0.6.1 (/Users/jiacai/code/misc/oss-rust-sdk)
│       ├── oss-rust-sdk feature "default" (command-line)
│       ├── oss-rust-sdk feature "native-tls" (*)
│       └── oss-rust-sdk feature "reqwest"
│           └── oss-rust-sdk feature "native-tls" (*)
├── reqwest feature "default-tls" (*)
├── reqwest feature "hyper-tls"
│   └── reqwest feature "default-tls" (*)
├── reqwest feature "native-tls-crate"
│   └── reqwest feature "default-tls" (*)
└── reqwest feature "tokio-native-tls"
    └── reqwest feature "default-tls" (*)
```

# Rustls

```
cargo tree -e features -i reqwest --no-default-features --features rustls-tls
reqwest v0.11.14
├── reqwest feature "__rustls"
│   └── reqwest feature "rustls-tls-webpki-roots"
│       └── reqwest feature "rustls-tls"
│           └── oss-rust-sdk feature "rustls-tls" (command-line)
├── reqwest feature "__tls"
│   └── reqwest feature "__rustls" (*)
├── reqwest feature "blocking"
│   └── oss-rust-sdk v0.6.1 (/Users/jiacai/code/misc/oss-rust-sdk)
│       ├── oss-rust-sdk feature "reqwest"
│       │   └── oss-rust-sdk feature "rustls-tls" (command-line)
│       └── oss-rust-sdk feature "rustls-tls" (command-line)
├── reqwest feature "hyper-rustls"
│   └── reqwest feature "__rustls" (*)
├── reqwest feature "rustls"
│   └── reqwest feature "__rustls" (*)
├── reqwest feature "rustls-pemfile"
│   └── reqwest feature "__rustls" (*)
├── reqwest feature "rustls-tls" (*)
├── reqwest feature "rustls-tls-webpki-roots" (*)
├── reqwest feature "tokio-rustls"
│   └── reqwest feature "__rustls" (*)
└── reqwest feature "webpki-roots"
    └── reqwest feature "rustls-tls-webpki-roots" (*)

```